### PR TITLE
Postgres environment variables renamed

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,8 +49,8 @@ services:
         container_name: super-db
         environment:
             PGHOST: "super-db"
-            PGUSER: "postgres"
-            PGPASSWORD: "postgres"
+            POSTGRES_USER: "postgres"
+            POSTGRES_PASSWORD: "postgres"
         ports:
             - "5432:5432"
         volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,8 @@ services:
 
     result:
         build: ./PoC-result
+        volumes:
+            - "m2-data:/root/.m2"
         networks:
             - front-tier
             - back-tier
@@ -60,6 +62,7 @@ services:
 
 volumes:
     db-data:
+    m2-data:
 
 networks:
     front-tier:


### PR DESCRIPTION
The environment variable in `./docker-compose.yml` file `PGUSER` and `PGPASSWORD` did not work. Looking at the [Official Postgres Dockerhub](https://hub.docker.com/_/postgres) (scroll down to the "Environment Variables" section), Postgres advises using `POSTGRES_USER` and `POSTGRES_PASSWORD` for username and password respectively.

Changing the environment variable to those suggested in the Postgres Dockerhub made it work.

Do check if the new `docker-compose.yml` file works on other (your) machines too.

P.S. Also optimised the docker build process for PoC-result!